### PR TITLE
Critical Bug Fixes

### DIFF
--- a/godaddy-dns.js
+++ b/godaddy-dns.js
@@ -5,7 +5,6 @@
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
-const extend = require('util')._extend;
 const program = require('commander');
 const request = require('request');
 const pkg = require('./package.json');
@@ -80,8 +79,8 @@ function updateRecords(ip) {
 		if (typeof record === 'string') {
 			record = {name: record};
 		}
-		return extend(recordDefaults, record);
-	})
+		return Object.assign(record, recordDefaults);
+	});
 
 	let options = {
 		method: 'PUT',

--- a/godaddy-dns.js
+++ b/godaddy-dns.js
@@ -2,11 +2,12 @@
 
 'use strict';
 
+const Promise = require('bluebird');
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const program = require('commander');
-const request = require('request');
+const request = require('request-promise');
 const pkg = require('./package.json');
 
 const defaultConfigFile = path.join(os.homedir(),'.godaddy-dns.json');
@@ -23,15 +24,7 @@ const config = JSON.parse(fs.readFileSync(program.config || defaultConfigFile, '
 const lastIpFile = program.ipfile || defaultLastIpFile;
 
 function getCurrentIp() {
-	return new Promise((resolve, reject) => {
-		request('https://api.ipify.org/', (err, response, ip) => {
-			if (err) {
-				return reject(err);
-			}
-
-			resolve(ip);
-		});
-	});
+    return request('https://api.ipify.org/');
 }
 
 function getLastIp() {
@@ -82,30 +75,24 @@ function updateRecords(ip) {
 		return Object.assign(record, recordDefaults);
 	});
 
-	let options = {
-		method: 'PUT',
-		url: `https://api.godaddy.com/v1/domains/${config.domain}/records/${records[0].type}/${records[0].name.replace("@","%40")}`,
-		headers: {
-			authorization: `sso-key ${config.apiKey}:${config.secret}`,
-			'content-type': 'application/json'
-		},
-		body: records,
-		json: true
-	};
+	return Promise.resolve(records)
+	    .each((record) => {
 
-	return new Promise((resolve, reject) => {
-		request(options, (err, response, body) => {
-			if (err) {
-				return reject(`Failed request to GoDaddy Api ${err}`);
-			};
+            let options = {
+                method: 'PUT',
+                url: `https://api.godaddy.com/v1/domains/${config.domain}/records/${record.type}/${record.name.replace("@","%40")}`,
+                headers: {
+                    authorization: `sso-key ${config.apiKey}:${config.secret}`,
+                    'content-type': 'application/json'
+                },
+                body: record,
+                json: true
+            };
 
-			if (response.statusCode !== 200) {
-				return reject(`Failed request to GoDaddy Api ${body.message}`);
-			}
+            return request(options);
 
-			resolve(body);
-		});
-	});
+	    });
+
 }
 
 let lastIp;

--- a/package.json
+++ b/package.json
@@ -3,30 +3,32 @@
   "version": "1.0.1",
   "description": "A Node.js script to programmatically update GoDaddy DNS records",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/lmammino/godaddy-dns.git"
+    "type": "git",
+    "url": "https://github.com/lmammino/godaddy-dns.git"
   },
-  "license" : {
-    "type" : "MIT",
-    "url" : "https://raw.githubusercontent.com/lmammino/godaddy-dns/master/LICENSE"
+  "license": {
+    "type": "MIT",
+    "url": "https://raw.githubusercontent.com/lmammino/godaddy-dns/master/LICENSE"
   },
-  "bin" : {
-    "godaddy-dns" : "./godaddy-dns.js"
+  "bin": {
+    "godaddy-dns": "./godaddy-dns.js"
   },
   "scripts": {
     "test": "./node_modules/.bin/xo index.js"
   },
   "author": {
-    "name" : "Luciano Mammino",
-    "email" : "lucianomammino@gmail.com",
-    "url" : "http://loige.co"
+    "name": "Luciano Mammino",
+    "email": "lucianomammino@gmail.com",
+    "url": "http://loige.co"
   },
-  "engines" : {
-    "node" : ">=4.0.0"
+  "engines": {
+    "node": ">=4.0.0"
   },
   "dependencies": {
+    "bluebird": "^3.4.6",
     "commander": "^2.9.0",
-    "request": "^2.72.0"
+    "request": "^2.72.0",
+    "request-promise": "^4.1.1"
   },
   "devDependencies": {
     "xo": "^0.15.0"


### PR DESCRIPTION
Thanks for putting this together - it's super useful and allows me to avoid paying for DynDNS.

This PR fixes a critical bug that - so far as I can tell - completely prevents DNS updates from taking place when you provide an array of changes. For example, consider the following config file:

```
{
    "apiKey": "...",
    "secret": "...",
    "domain": "domain.com",
    "records": [
        {
            "type": "A",
            "name": "home",
            "ttl": 600
        },
        {
            "type": "A",
            "name": "chat",
            "ttl": 600
        },
        {
            "type": "A",
            "name": "cloud",
            "ttl": 600
        }
    ]
}
```

As it stands, when I run this utility, GoDaddy reports the following error:

`Another record with the same attributes already exists.`

This is the result (in part) of incorrect usage of Node's (deprecated) `util._extend()` method.