### PR TITLE
Send `record` as array

### DIFF
--- a/src/updateRecords.js
+++ b/src/updateRecords.js
@@ -34,7 +34,7 @@ module.exports = function updateRecords (ip, config) {
           'authorization': `sso-key ${config.apiKey}:${config.secret}`,
           'content-type': 'application/json'
         },
-        body: record,
+        body: [record],
         json: true
       }
       return request(options)


### PR DESCRIPTION
As per https://developer.godaddy.com/doc/endpoint/domains#/v1/recordReplaceTypeName

I was getting the following error before:

```
[Thu Apr 19 2018 08:27:45 GMT+0200 (CEST)] StatusCodeError: 422 - {"code":"INVALID_BODY","fields":[{"code":"UNEXPECTED_TYPE","message":"is not a array","path":"records"}],"message":"Request body doesn't fulfill schema, see details in `fields`"}
```